### PR TITLE
some improvements

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -107,6 +107,7 @@ async fn requestqr_fn(mut req: Request<State>) -> tide::Result {
     uuid.truncate(5);
     let group_name = format!("LoginBot group {uuid}");
     let state = req.state();
+    // TODO check first if group for the session already exists?
     let group =
         create_group_chat(&state.dc_context, ProtectionStatus::Protected, &group_name).await?;
     let mut body = Body::from_string(get_securejoin_qr_svg(&state.dc_context, Some(group)).await?);

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,11 +117,10 @@ async fn requestqr_fn(mut req: Request<State>) -> tide::Result {
 }
 
 async fn check_status_fn(mut req: Request<State>) -> tide::Result {
-    if let Some(group_id) = req.session().get::<String>("group_id") {
+    if let Some(group_id) = req.session().get::<u32>("group_id") {
         let dc_context = &req.state().dc_context;
         log::info!("Getting chat members for group {group_id}");
-        let chat_members =
-            get_chat_contacts(dc_context, ChatId::new(u32::from_str_radix(&group_id, 10)?)).await?;
+        let chat_members = get_chat_contacts(dc_context, ChatId::new(group_id)).await?;
         match chat_members.len() {
             1 => Ok(Response::builder(200)
                 .body(Body::from_json(&json!({"waiting": true}))?)

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,6 +84,8 @@ async fn main() -> anyhow::Result<()> {
         ctx.set_config(Config::E2eeEnabled, Some("1")).await?;
         ctx.configure().await.context("configuration failed...")?;
     }
+    // connect to email server
+    ctx.start_io().await;
 
     backend.listen(botconfig.listen_addr.clone()).await?;
     tokio::signal::ctrl_c().await?;
@@ -142,7 +144,7 @@ async fn check_status_fn(mut req: Request<State>) -> tide::Result {
             }
             number_of_members => {
                 log::error!("{}", format!("This must not happen. There is/are {number_of_members} in the group {group_id}"));
-                return Err(tide::Error::from_str(500, "Some internal error occured..."));
+                Err(tide::Error::from_str(500, "Some internal error occured..."))
             }
         }
     } else {


### PR DESCRIPTION
- add a todo comment for later
- normal errors are already converted to tide errors, so no need to manualy set an 500 response.
- Bugfix: group_id in session is an u32, it can not be read as string.
- bugfix: deltachat was not started yet
- log deltachat events

in the end I fixed the bugs that prevented me from testing the api, also I added some todo comments.
