### PR TITLE
fix: also set configured_addr from config.toml

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -61,8 +61,11 @@ async fn main() -> anyhow::Result<()> {
         log::info!("Configure deltachat context");
         ctx.set_config(Config::Addr, Some(botconfig.email.clone().as_str()))
             .await?;
-        ctx.set_config(Config::ConfiguredAddr, Some(botconfig.email.clone().as_str()))
-            .await?;
+        ctx.set_config(
+            Config::ConfiguredAddr,
+            Some(botconfig.email.clone().as_str()),
+        )
+        .await?;
         ctx.set_config(Config::MailPw, Some(botconfig.password.clone().as_str()))
             .await?;
         ctx.set_config(Config::Bot, Some("1")).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,8 @@ async fn main() -> anyhow::Result<()> {
         log::info!("Configure deltachat context");
         ctx.set_config(Config::Addr, Some(botconfig.email.clone().as_str()))
             .await?;
+        ctx.set_config(Config::ConfiguredAddr, Some(botconfig.email.clone().as_str()))
+            .await?;
         ctx.set_config(Config::MailPw, Some(botconfig.password.clone().as_str()))
             .await?;
         ctx.set_config(Config::Bot, Some("1")).await?;


### PR DESCRIPTION
This was necessary to do manually in https://github.com/deltachat/sysadmin/pull/291 to change the bot's address, so I guess it makes sense to add this as well.